### PR TITLE
change upcoming filter in manager modal from selecto to radio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Change upcoming filter in manager modal from select to radio
+
 ## 1.0.0 - 2021-12-08
 
 * Initial release with support for event pieces and event piece pages. Many thanks to [bulldoguk](https://github.com/bulldoguk) for primary module development and [egonzalezg9](https://github.com/egonzalezg9) for additional contributions.

--- a/filters.js
+++ b/filters.js
@@ -2,7 +2,7 @@ module.exports = {
   add: {
     upcoming: {
       label: 'aposEvent:filterUpcoming',
-      inputType: 'select',
+      inputType: 'radio',
       def: true
     },
     year: {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Change `upcoming` filter from select to radio.

Filter values are boolean and select vue component expects a string or a number.

## What are the specific steps to test this change?

1. Enable `@apostrophecms/event` module and set it up
2. Run the website and log in as an admin
3. Open event piece manager modal and select several pieces
4. Check the browser console for errors
5. Use the upcoming filter and check the result

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
